### PR TITLE
Flatten models as inputs to enclave

### DIFF
--- a/python-package/secagg/core.py
+++ b/python-package/secagg/core.py
@@ -4,8 +4,8 @@ import os
 
 # FIXME: remove this hardcoded path
 #  _LIB = ctypes.CDLL(os.path.dirname(os.path.abspath(__file__)) + "/../../server/build/host/libmodelaggregator_host.so")
-#  _LIB = ctypes.CDLL("/home/davidyi624/kvah/server/build/host/libmodelaggregator_host.so")
-_LIB = ctypes.CDLL("/usr/local/nvidia/lib/libmodelaggregator_host.so")
+_LIB = ctypes.CDLL("/home/davidyi624/kvah/server/build/host/libmodelaggregator_host.so")
+#  _LIB = ctypes.CDLL("/usr/local/nvidia/lib/libmodelaggregator_host.so")
 
 IV_LENGTH = 12
 TAG_LENGTH = 16

--- a/python-package/secagg/core.py
+++ b/python-package/secagg/core.py
@@ -4,8 +4,8 @@ import os
 
 # FIXME: remove this hardcoded path
 #  _LIB = ctypes.CDLL(os.path.dirname(os.path.abspath(__file__)) + "/../../server/build/host/libmodelaggregator_host.so")
-_LIB = ctypes.CDLL("/home/davidyi624/kvah/server/build/host/libmodelaggregator_host.so")
-#  _LIB = ctypes.CDLL("/usr/local/nvidia/lib/libmodelaggregator_host.so")
+#  _LIB = ctypes.CDLL("/home/davidyi624/kvah/server/build/host/libmodelaggregator_host.so")
+_LIB = ctypes.CDLL("/usr/local/nvidia/lib/libmodelaggregator_host.so")
 
 IV_LENGTH = 12
 TAG_LENGTH = 16

--- a/server/enclave/ecalls.cpp
+++ b/server/enclave/ecalls.cpp
@@ -179,8 +179,23 @@ void enclave_transfer_model_out(uint8_t** encrypted_new_params_ptr, size_t* new_
     free(serialized_new_params);
 
     // Clear the global variables before the next round of training
+    for (auto& params : g_accumulator) {
+        for (auto& feature : params) {
+            feature.second.clear();
+            // vector<float>().swap(feature.second);
+            feature.second.shrink_to_fit();
+        }
+        params.clear();
+        // vector<float>().swap(params);
+        params.shrink_to_fit();
+    }
     g_accumulator.clear();
     g_vars_to_aggregate.clear();
+
+    for (auto& feature : g_old_params) {
+        feature.second.clear();
+        feature.second.shrink_to_fit();
+    }
     g_old_params.clear();
     g_contributions.clear();
 }

--- a/server/host/enclave.h
+++ b/server/host/enclave.h
@@ -1,47 +1,32 @@
 #include "modelaggregator_u.h"
+#include <openenclave/host.h>
 
 class Enclave {
-    private:
-        int num_clients;
-        oe_enclave_t* enclave_ref;
-        oe_result_t enclave_ret;
+   private:
+       // Private constructor to prevent instancing
+       Enclave() {}
 
-    public:
+   public:
+       // Don't forget to declare these two. You want to make sure they
+       // are unacceptable otherwise you may accidentally get copies of
+       // your singleton appearing.
+       Enclave (Enclave const&) = delete;
+       void operator=(Enclave const&) = delete;
 
-        Enclave(char* path, uint32_t flags)
-        {
-            enclave_ret = oe_create_modelaggregator_enclave(
-                path, OE_ENCLAVE_TYPE_AUTO, flags, NULL, 0, &this->enclave_ref);
-        }
+       oe_enclave_t* enclave_ref;
+       int enclave_ret;
 
-        oe_enclave_t* getEnclave() 
-        {
-            return this->enclave_ref;
-        }
+       static Enclave& getInstance() {
+           static Enclave instance;
+           return instance;
+       }
 
-        oe_enclave_t** getEnclaveRef() 
-        {
-            return &(this->enclave_ref);
-        }
+       oe_enclave_t* getEnclave() {
+           return this->enclave_ref;
+       }
 
-        oe_result_t getEnclaveRet() 
-        {
-            return this->enclave_ret;
-        }
+       oe_enclave_t** getEnclaveRef() {
+           return &(this->enclave_ref);
+       }
 
-
-        int set_num_clients(int num) 
-        {
-          num_clients = num;
-        }
-
-        int get_num_clients() 
-        {
-          return num_clients;
-        }
-
-        int terminate()
-        {
-            oe_terminate_enclave(enclave_ref);
-        }
 };

--- a/server/host/host.cpp
+++ b/server/host/host.cpp
@@ -10,8 +10,8 @@ using namespace std;
 
 // FIXME: remove this hardcoded path
 // static char* g_path = "./enclave/enclave.signed";
-static char* g_path = "/home/davidyi624/kvah/server/build/enclave/enclave.signed";
-// static char* g_path = "/workspace/kvah/server/build/enclave/enclave.signed";
+// static char* g_path = "/home/davidyi624/kvah/server/build/enclave/enclave.signed";
+static char* g_path = "/workspace/kvah/server/build/enclave/enclave.signed";
 
 // Cannot be larger than NumTCS in modelaggregator.conf
 static const int NUM_THREADS = 1;

--- a/server/host/host.cpp
+++ b/server/host/host.cpp
@@ -1,5 +1,4 @@
 #include <omp.h>
-#include <iostream>
 #include "enclave.h"
 
 // Include the untrusted modelaggregator header that is generated
@@ -56,9 +55,7 @@ int host_modelaggregator(uint8_t** encrypted_accumulator,
           oe_terminate_enclave(Enclave::getInstance().getEnclave());
           return Enclave::getInstance().enclave_ret;
         }
-  }
-    
-
+    }
     oe_result_t error;
 
     error = enclave_store_globals(Enclave::getInstance().getEnclave(),


### PR DESCRIPTION
* Enclave now accepts a model as a 1D array (data || IV || tag) instead of as a 2D array ([0]: data, [1]: IV, [2] : tag)
* Clears and shrinks global vectors that were used to store local model updates and old params in enclave